### PR TITLE
feat: #4  specフォルダを検証から除去

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,9 +12,10 @@ LineLength:
 #rubocopで検証したくないフォルダを指定
 AllCops:
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'bin/*'
-    - '**/Gemfile'
-    - 'vendor/**/*'
-    - '.git/**/*'
+    - "db/**/*"
+    - "config/**/*"
+    - "bin/*"
+    - "**/Gemfile"
+    - "vendor/**/*"
+    - ".git/**/*"
+    - "spec/*"


### PR DESCRIPTION
why
RuboCopの設定確認のため

what
specフォルダを検証から除去